### PR TITLE
Updated pcsclite version && fixed buffer deprecated errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Tema Smirnov",
   "license": "MIT",
   "dependencies": {
-    "pcsclite": "^0.4.9"
+    "pcsclite": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -67,7 +67,7 @@ class Reader extends EventEmitter {
 	}
 
 	static reverseBuffer(src) {
-		let buffer = new Buffer(src.length);
+		let buffer = Buffer.alloc(src.length);
 		for (var i = 0, j = src.length - 1; i <= j; ++i, --j) {
 			buffer[i] = src[j];
 			buffer[j] = src[i];
@@ -92,7 +92,7 @@ class Reader extends EventEmitter {
 
 	getTagUid(protocol) {
 
-		let packet = new Buffer([
+		let packet = Buffer.from([
 			0xFF, // Class
 			0xCA, // Ins
 			0x00, // P1: Get current card UID


### PR DESCRIPTION
- Updated pcsclite library version.
- `new Buffer()` has been deprecated. Updated the code to use `Buffer.from()` and `Buffer.alloc()`.